### PR TITLE
Moved States tests to package "states" because actual state classes

### DIFF
--- a/src/main/java/com/spanish_inquisition/battleship/server/MessageBus.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/MessageBus.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class MessageBus {
     private Queue<Message> messageBus;
 
-    MessageBus() {
+    public MessageBus() {
         messageBus = new ConcurrentLinkedQueue<>();
         AppLogger.initializeLogger();
     }

--- a/src/main/java/com/spanish_inquisition/battleship/server/Player.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/Player.java
@@ -25,4 +25,8 @@ public class Player {
     public Fleet getFleet() {
         return fleet;
     }
+
+    public boolean hasNoFleet() {
+        return fleet.hasNoShips();
+    }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/fleet/Fleet.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/fleet/Fleet.java
@@ -19,4 +19,8 @@ public class Fleet {
                 "ships=" + ships +
                 '}';
     }
+
+    public boolean hasNoShips() {
+        return ships.isEmpty();
+    }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/ResultState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/ResultState.java
@@ -1,0 +1,17 @@
+package com.spanish_inquisition.battleship.server.game_states;
+
+import com.spanish_inquisition.battleship.server.MessageBus;
+import com.spanish_inquisition.battleship.server.Players;
+
+public class ResultState extends GameState {
+    public ResultState(Players players, MessageBus requestBus) {
+        super(players, requestBus);
+    }
+
+    @Override
+    public GameState transform() {
+        //TODO: notify players about match result
+        //if this state is invoked, right now opponent of current player won
+        return new EndState(players, requestBus);
+    }
+}

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/ShotState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/ShotState.java
@@ -1,5 +1,6 @@
 package com.spanish_inquisition.battleship.server.game_states;
 
+import com.spanish_inquisition.battleship.common.Header;
 import com.spanish_inquisition.battleship.server.MessageBus;
 import com.spanish_inquisition.battleship.server.Player;
 import com.spanish_inquisition.battleship.server.Players;
@@ -13,9 +14,35 @@ public class ShotState extends GameState {
 
     @Override
     public GameState transform() {
-        if (requestBus.haveMessageFromSender(players.getCurrentPlayer().getPlayerId())) {
-            //TODO get message &
+        Player currentPlayer = getCurrentPlayer();
+        if(!shootIfPlayerSentValidMessage(currentPlayer)) {
+            return this;
         }
-        return null;
+        return !didPlayerWon(currentPlayer) ?
+                new PlayerActionState(players, requestBus) : new ResultState(players, requestBus);
+    }
+
+    private boolean didPlayerWon(Player player) {
+        return players.getOpponentOf(player).hasNoFleet();
+    }
+
+    private boolean shootIfPlayerSentValidMessage(Player player) {
+        if (requestBus.haveMessageFromSender(player.getPlayerId())) {
+            String shotMessage = getMessageContentFromPlayer(player);
+            if (shotMessage.contains(Header.MOVE_REGULAR.name())) {
+                //TODO: implement shoot event, notify players
+                players.switchCurrentPlayer();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Player getCurrentPlayer() {
+        return players.getCurrentPlayer();
+    }
+
+    private String getMessageContentFromPlayer(Player player) {
+        return requestBus.getMessageFrom(player.getPlayerId()).getContent();
     }
 }

--- a/src/test/java/com/spanish_inquisition/battleship/server/game_states/EndStateTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/server/game_states/EndStateTest.java
@@ -1,5 +1,7 @@
-package com.spanish_inquisition.battleship.server;
+package com.spanish_inquisition.battleship.server.game_states;
 
+import com.spanish_inquisition.battleship.server.MessageBus;
+import com.spanish_inquisition.battleship.server.Players;
 import com.spanish_inquisition.battleship.server.game_states.EndState;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/com/spanish_inquisition/battleship/server/game_states/GameStateTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/server/game_states/GameStateTest.java
@@ -1,5 +1,7 @@
-package com.spanish_inquisition.battleship.server;
+package com.spanish_inquisition.battleship.server.game_states;
 
+import com.spanish_inquisition.battleship.server.MessageBus;
+import com.spanish_inquisition.battleship.server.Players;
 import com.spanish_inquisition.battleship.server.game_states.GameState;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsStateTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsStateTest.java
@@ -79,17 +79,18 @@ public class PlacingShipsStateTest {
         }
 
         for(List<Ship> playerShips : playersShips) {
-            new SoftAssert().assertEquals(10, playerShips.size());
-            new SoftAssert().assertEquals(1, playerShips.get(0).getShipPoints().size());
-            new SoftAssert().assertEquals(1, playerShips.get(1).getShipPoints().size());
-            new SoftAssert().assertEquals(1, playerShips.get(2).getShipPoints().size());
-            new SoftAssert().assertEquals(1, playerShips.get(3).getShipPoints().size());
-            new SoftAssert().assertEquals(2, playerShips.get(4).getShipPoints().size());
-            new SoftAssert().assertEquals(2, playerShips.get(5).getShipPoints().size());
-            new SoftAssert().assertEquals(2, playerShips.get(6).getShipPoints().size());
-            new SoftAssert().assertEquals(3, playerShips.get(7).getShipPoints().size());
-            new SoftAssert().assertEquals(3, playerShips.get(8).getShipPoints().size());
-            new SoftAssert().assertEquals(4, playerShips.get(9).getShipPoints().size());
+            SoftAssert soft = new SoftAssert();
+            soft.assertEquals(10, playerShips.size());
+            soft.assertEquals(1, playerShips.get(0).getShipPoints().size());
+            soft.assertEquals(1, playerShips.get(1).getShipPoints().size());
+            soft.assertEquals(1, playerShips.get(2).getShipPoints().size());
+            soft.assertEquals(1, playerShips.get(3).getShipPoints().size());
+            soft.assertEquals(2, playerShips.get(4).getShipPoints().size());
+            soft.assertEquals(2, playerShips.get(5).getShipPoints().size());
+            soft.assertEquals(2, playerShips.get(6).getShipPoints().size());
+            soft.assertEquals(3, playerShips.get(7).getShipPoints().size());
+            soft.assertEquals(3, playerShips.get(8).getShipPoints().size());
+            soft.assertEquals(4, playerShips.get(9).getShipPoints().size());
         }
     }
 

--- a/src/test/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsStateTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsStateTest.java
@@ -1,6 +1,10 @@
-package com.spanish_inquisition.battleship.server;
+package com.spanish_inquisition.battleship.server.game_states;
 
 import com.spanish_inquisition.battleship.common.Header;
+import com.spanish_inquisition.battleship.server.ClientConnectionHandler;
+import com.spanish_inquisition.battleship.server.MessageBus;
+import com.spanish_inquisition.battleship.server.Player;
+import com.spanish_inquisition.battleship.server.Players;
 import com.spanish_inquisition.battleship.server.fleet.Ship;
 import com.spanish_inquisition.battleship.server.game_states.GameState;
 import com.spanish_inquisition.battleship.server.game_states.PlacingShipsState;
@@ -8,6 +12,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -21,7 +26,7 @@ import static com.spanish_inquisition.battleship.common.AppLogger.logger;
 
 public class PlacingShipsStateTest {
     Players players;
-    private int TEST_PORT = 5550;
+    private int TEST_PORT = 5559;
     MessageBus messageBus;
     ServerSocket ss;
     String SERVER_ADDRESS = "localhost";
@@ -74,17 +79,17 @@ public class PlacingShipsStateTest {
         }
 
         for(List<Ship> playerShips : playersShips) {
-            Assert.assertEquals(10, playerShips.size());
-            Assert.assertEquals(1, playerShips.get(0).getShipPoints().size());
-            Assert.assertEquals(1, playerShips.get(1).getShipPoints().size());
-            Assert.assertEquals(1, playerShips.get(2).getShipPoints().size());
-            Assert.assertEquals(1, playerShips.get(3).getShipPoints().size());
-            Assert.assertEquals(2, playerShips.get(4).getShipPoints().size());
-            Assert.assertEquals(2, playerShips.get(5).getShipPoints().size());
-            Assert.assertEquals(2, playerShips.get(6).getShipPoints().size());
-            Assert.assertEquals(3, playerShips.get(7).getShipPoints().size());
-            Assert.assertEquals(3, playerShips.get(8).getShipPoints().size());
-            Assert.assertEquals(4, playerShips.get(9).getShipPoints().size());
+            new SoftAssert().assertEquals(10, playerShips.size());
+            new SoftAssert().assertEquals(1, playerShips.get(0).getShipPoints().size());
+            new SoftAssert().assertEquals(1, playerShips.get(1).getShipPoints().size());
+            new SoftAssert().assertEquals(1, playerShips.get(2).getShipPoints().size());
+            new SoftAssert().assertEquals(1, playerShips.get(3).getShipPoints().size());
+            new SoftAssert().assertEquals(2, playerShips.get(4).getShipPoints().size());
+            new SoftAssert().assertEquals(2, playerShips.get(5).getShipPoints().size());
+            new SoftAssert().assertEquals(2, playerShips.get(6).getShipPoints().size());
+            new SoftAssert().assertEquals(3, playerShips.get(7).getShipPoints().size());
+            new SoftAssert().assertEquals(3, playerShips.get(8).getShipPoints().size());
+            new SoftAssert().assertEquals(4, playerShips.get(9).getShipPoints().size());
         }
     }
 

--- a/src/test/java/com/spanish_inquisition/battleship/server/game_states/ShotStateTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/server/game_states/ShotStateTest.java
@@ -1,0 +1,96 @@
+package com.spanish_inquisition.battleship.server.game_states;
+
+import com.spanish_inquisition.battleship.client.game.Game;
+import com.spanish_inquisition.battleship.common.Header;
+import com.spanish_inquisition.battleship.server.ClientConnectionHandler;
+import com.spanish_inquisition.battleship.server.MessageBus;
+import com.spanish_inquisition.battleship.server.Player;
+import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.fleet.FleetBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.logging.Level;
+
+import static com.spanish_inquisition.battleship.common.AppLogger.logger;
+import static org.testng.Assert.*;
+
+public class ShotStateTest {
+    Players players;
+    private int TEST_PORT = 5552;
+    MessageBus messageBus;
+    ServerSocket ss;
+    String SERVER_ADDRESS = "localhost";
+
+    @BeforeTest
+    public void initialize() {
+        messageBus = new MessageBus();
+        try {
+            ss = new ServerSocket(TEST_PORT);
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "couldn't create server socket", e);
+        }
+        new Thread(() -> assignSocketAndNameTo("Name 1")).run();
+        new Thread(() -> assignSocketAndNameTo("Name 2")).run();
+        players = new Players();
+        for(int i = 1; i < 3; i++) {
+            ClientConnectionHandler cch = new ClientConnectionHandler(i, messageBus);
+            cch.start();
+            try {
+                cch.initializeSocket(ss);
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "couldn't connect with server", e);
+            }
+            players.addPlayer(new Player(cch));
+        }
+    }
+
+    private void assignSocketAndNameTo(String nameString) {
+        try {
+            Socket theClient = new Socket(SERVER_ADDRESS, TEST_PORT);
+            PrintWriter writer = new PrintWriter(theClient.getOutputStream(), true);
+            writer.println(nameString);
+            theClient.close();
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "could't connect to server", e);
+        }
+    }
+
+    @Test
+    public void testShootMessageWithInvalidHeader() {
+        GameState ss = new ShotState(players, messageBus);
+        messageBus.addMessage(1,0, Header.FLEET_REQUEST.name()+":1;");
+        ss = ss.transform();
+        Assert.assertEquals(ShotState.class, ss.getClass());
+    }
+
+    @Test
+    public void testShootMessageWithValidHeader() {
+        GameState ss = new ShotState(players, messageBus);
+        messageBus.addMessage(1,0, Header.MOVE_REGULAR.name()+":1;");
+        players.getOpponentOf(players.getCurrentPlayer()).setFleet(
+                new FleetBuilder().build(
+                        Header.FLEET_REQUEST.name() +
+                                ":[0,2,4,6,8,9,20,21,23,24,26,27,28,40,41,42,44,45,46,47];"
+                ));
+        ss = ss.transform();
+        Assert.assertEquals(PlayerActionState.class, ss.getClass());
+    }
+
+    @AfterTest
+    public void closeConnections(){
+        try {
+            ss.close();
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "couldn't close server",e);
+        }
+    }
+}


### PR DESCRIPTION
have been moved to adequate package before.

Finished implementing player turns, but to completely close that case
Shot state needs to be implemented.

Message bus constructor has been made public due to state tests package
migration.

Introduced ResultState which will be activated when one of the players
will have no fleet available and to meet that condition Player and
Fleet classes needed to have introduced corresponding methods.