### PR TITLE
Organize imports; divide too long lines; add missing spaces

### DIFF
--- a/src/main/java/com/spanish_inquisition/battleship/client/Client.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/Client.java
@@ -39,7 +39,7 @@ public class Client extends Application {
         MainMenuController mainMenuController = loader.getController();
         String serverIP = argsRaw.isEmpty() ? "localhost" : argsRaw.get(0);
         mainMenuController.setHostIP(serverIP);
-        if(argsRaw.size() > 1) {
+        if (argsRaw.size() > 1) {
             int port = Integer.parseInt(argsRaw.get(1));
             mainMenuController.setPort(port);
         }

--- a/src/main/java/com/spanish_inquisition/battleship/client/StatusController.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/StatusController.java
@@ -9,11 +9,11 @@ import javafx.scene.control.Label;
 public class StatusController {
     private Label statusLabel;
 
-    public StatusController(Label statusLabel) {
+    StatusController(Label statusLabel) {
         this.statusLabel = statusLabel;
     }
 
-    public void setPlayersLabel(String status){
+    public void setPlayersLabel(String status) {
         Platform.runLater(() -> statusLabel.setText(status));
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/client/board/GameBoardBuilder.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/board/GameBoardBuilder.java
@@ -40,11 +40,7 @@ public class GameBoardBuilder {
         this.gridPane = boardController.getBoardGridPane();
     }
 
-    public void buildGameBoard() {
-        fillTheBoardWithButtonsAndLabels();
-    }
-
-    private void fillTheBoardWithButtonsAndLabels() {
+    public void fillTheBoardWithButtonsAndLabels() {
         for (int column = 0; column < BOARD_SIZE_WITH_LABELS; column++) {
             Platform.runLater(() -> gridPane.getRowConstraints().add(new RowConstraints(FIELD_SIZE)));
             for (int row = 0; row < BOARD_SIZE_WITH_LABELS; row++) {
@@ -109,8 +105,9 @@ public class GameBoardBuilder {
     }
 
     private EventHandler<MouseEvent> getOnBoardTileClickedEvent(BoardTile tile, BoardController boardController) {
-        if(boardController instanceof PlayerBoardController) {
-            return event -> {}; //TODO player impl
+        if (boardController instanceof PlayerBoardController) {
+            return event -> {
+            }; //TODO player impl
         } else {
             return event -> boardController.getGame().makeAMove(tile.getBoardIndex());
         }

--- a/src/main/java/com/spanish_inquisition/battleship/client/board/boardcontroller/OpponentBoardController.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/board/boardcontroller/OpponentBoardController.java
@@ -13,7 +13,7 @@ public class OpponentBoardController extends BoardController{
     @Override
     public void buildBoard() {
         GameBoardBuilder gameBoardBuilder = new GameBoardBuilder(this);
-        gameBoardBuilder.buildGameBoard();
+        gameBoardBuilder.fillTheBoardWithButtonsAndLabels();
     }
 
     public void setBoardDisabled(boolean disable) {

--- a/src/main/java/com/spanish_inquisition/battleship/client/board/boardcontroller/PlayerBoardController.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/board/boardcontroller/PlayerBoardController.java
@@ -22,7 +22,7 @@ public class PlayerBoardController extends BoardController {
     public void buildBoard() {
         GameBoardBuilder gameBoardBuilder = new GameBoardBuilder(this);
         fleetInitializer = new FleetInitializer(this);
-        gameBoardBuilder.buildGameBoard();
+        gameBoardBuilder.fillTheBoardWithButtonsAndLabels();
     }
 
     public void placeShips() {

--- a/src/main/java/com/spanish_inquisition/battleship/client/game/Fleet.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/game/Fleet.java
@@ -23,7 +23,7 @@ public enum Fleet {
     }
 
     public static Fleet getRandomFleet() {
-        Random r = new Random();
-        return values()[r.nextInt(values().length)];
+        Random random = new Random();
+        return values()[random.nextInt(values().length)];
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/client/game/FleetInitializer.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/game/FleetInitializer.java
@@ -1,7 +1,7 @@
 package com.spanish_inquisition.battleship.client.game;
 
-import com.spanish_inquisition.battleship.client.board.boardcontroller.BoardController;
 import com.spanish_inquisition.battleship.client.board.BoardTile;
+import com.spanish_inquisition.battleship.client.board.boardcontroller.BoardController;
 import com.spanish_inquisition.battleship.common.AppLogger;
 import com.spanish_inquisition.battleship.common.Styles;
 import javafx.application.Platform;

--- a/src/main/java/com/spanish_inquisition/battleship/client/game/Game.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/game/Game.java
@@ -53,12 +53,12 @@ public class Game {
         playerBoardController.placeShips();
     }
 
-    public String getShipPlacementForServer(){
+    public String getShipPlacementForServer() {
         return playerBoardController.getFleetMessageForServer();
     }
 
     public void sendTheFleetToServer() {
-        if(socketClient != null) {
+        if (socketClient != null) {
             socketClient.sendStringToServer(getShipPlacementForServer());
         }
     }
@@ -141,7 +141,7 @@ public class Game {
                     }
                     case GAME_WON: {
                         opponentBoardController.setBoardDisabled(true);
-                        if(message.getBody().equals("true")) {
+                        if (message.getBody().equals("true")) {
                             statusController.setPlayersLabel("You have won!");
                         } else {
                             statusController.setPlayersLabel("You lost!");
@@ -159,15 +159,16 @@ public class Game {
     }
 
     public void closeSocketConnection() {
-        if(socketClient != null) {
+        if (socketClient != null) {
             socketClient.closeTheSocketClient();
         }
     }
 
     public void makeAMove(Integer tileIndex) {
         logger.log(DEFAULT_LEVEL, "The tile index that was clicked " + tileIndex);
-        String regularMoveMessage = Header.MOVE_REGULAR + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER + tileIndex + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
-        if(socketClient != null) {
+        String regularMoveMessage = Header.MOVE_REGULAR + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + tileIndex + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        if (socketClient != null) {
             socketClient.sendStringToServer(regularMoveMessage);
         }
     }
@@ -178,7 +179,7 @@ public class Game {
         }
     }
 
-    public void stopGameRunning(){
+    public void stopGameRunning() {
         isGameRunning = false;
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/client/network/ResponsesBus.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/network/ResponsesBus.java
@@ -28,7 +28,7 @@ public class ResponsesBus {
     }
 
     void addAServerResponse(String response) {
-        logger.log(DEFAULT_LEVEL, "Response from server : " +response);
+        logger.log(DEFAULT_LEVEL, "Response from server : " + response);
         if (response == null || response.isEmpty()) {
             logger.info("Response empty");
             return;

--- a/src/main/java/com/spanish_inquisition/battleship/client/network/SocketClient.java
+++ b/src/main/java/com/spanish_inquisition/battleship/client/network/SocketClient.java
@@ -3,7 +3,11 @@ package com.spanish_inquisition.battleship.client.network;
 import com.spanish_inquisition.battleship.common.AppLogger;
 import com.spanish_inquisition.battleship.common.Header;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
@@ -15,7 +19,6 @@ import static com.spanish_inquisition.battleship.common.AppLogger.DEFAULT_LEVEL;
  * @author Michal_Partacz
  */
 public class SocketClient {
-    private static final String HOST_NAME = "localhost";
     static int PORT = 6666;
     private static final Logger logger = Logger.getLogger(AppLogger.class.getName());
     private static final int THREAD_TIMEOUT = 3_000; //[ms]
@@ -27,9 +30,12 @@ public class SocketClient {
     private boolean isRunning = true;
     Thread updatesThread;
 
-    SocketClient() {}
+    SocketClient() {
+    }
 
-    public ResponsesBus getResponsesBus() { return responsesBus; }
+    public ResponsesBus getResponsesBus() {
+        return responsesBus;
+    }
 
     void setUpStreamsOnSocket() throws IOException {
         logger.log(DEFAULT_LEVEL, "Setting up streams and socket");
@@ -66,7 +72,7 @@ public class SocketClient {
 
     String readUpdateFromServer() throws IOException {
         if (socket != null && output != null && input != null) {
-                return input.readLine();
+            return input.readLine();
         }
         return "";
     }

--- a/src/main/java/com/spanish_inquisition/battleship/common/AdjacentTilesCalc.java
+++ b/src/main/java/com/spanish_inquisition/battleship/common/AdjacentTilesCalc.java
@@ -10,22 +10,22 @@ import java.util.List;
  */
 public class AdjacentTilesCalc {
 
-    private static final int IMPORTED_BOARD_SIZE = GameBoardBuilder.BOARD_SIZE_WITH_LABELS -1;
+    private static final int IMPORTED_BOARD_SIZE = GameBoardBuilder.BOARD_SIZE_WITH_LABELS - 1;
     private static final int OUT_OF_BOARD_INDEX = -1;
 
-    public static List<Integer> getBoardIndexesOfAllAdjacentTilesOf(Integer tile) {
+    static List<Integer> getBoardIndexesOfAllAdjacentTilesOf(Integer tile) {
         List<Integer> adjacentFields = new LinkedList<>();
         TileDirection[] enumValues = TileDirection.values();
-        for (TileDirection tileDirection: enumValues) {
+        for (TileDirection tileDirection : enumValues) {
             int adjacentBoardIndex = getAdjacentTileIndex(tile, tileDirection);
-            if(adjacentBoardIndex != OUT_OF_BOARD_INDEX) {
+            if (adjacentBoardIndex != OUT_OF_BOARD_INDEX) {
                 adjacentFields.add(adjacentBoardIndex);
             }
         }
         return adjacentFields;
     }
 
-    public static int getAdjacentTileIndex(Integer boardIndex, TileDirection tileDirection) {
+    private static int getAdjacentTileIndex(Integer boardIndex, TileDirection tileDirection) {
         return tileDirection.getAdjacentTileIndex(boardIndex);
     }
 

--- a/src/main/java/com/spanish_inquisition/battleship/common/NetworkMessage.java
+++ b/src/main/java/com/spanish_inquisition/battleship/common/NetworkMessage.java
@@ -34,7 +34,6 @@ public class NetworkMessage {
             return Arrays.stream(responses).map(Parser::parseSingleResponse).collect(Collectors.toList());
         }
 
-
         static NetworkMessage parseSingleResponse(String rawSingleResponse) {
             String[] responseParts = rawSingleResponse.split(RESPONSE_HEADER_SPLIT_CHARACTER);
             Header header = Header.parseResponseHeader(responseParts[0]);
@@ -58,8 +57,12 @@ public class NetworkMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         NetworkMessage that = (NetworkMessage) o;
         return header == that.header && (body != null ? body.equals(that.body) : that.body == null);
     }

--- a/src/main/java/com/spanish_inquisition/battleship/server/BattleshipServer.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/BattleshipServer.java
@@ -17,14 +17,14 @@ public class BattleshipServer {
     private static final Integer PORT_NUMBER = 6666;
     static final int NUMBER_OF_PLAYERS = 2;
     public static final int SERVER_ID = 0;
-    MessageBus requestBus;
+    private MessageBus requestBus;
     List<ClientConnectionHandler> clients;
 
-    public BattleshipServer(){
+    public BattleshipServer() {
         requestBus = new MessageBus();
     }
 
-    public void proceed(){
+    void proceed() {
         initializeLogger();
         connectWithPlayers(createServerSocket(PORT_NUMBER));
         BattleshipGame game = new BattleshipGame(clients, requestBus);
@@ -35,7 +35,8 @@ public class BattleshipServer {
         ServerSocket serverSocket = null;
         try {
             serverSocket = new ServerSocket(portNumber);
-            logger.log(DEFAULT_LEVEL, "IP ADDRESS OF THE SERVER: " +InetAddress.getLocalHost().toString().split("/")[1]);
+            logger.log(DEFAULT_LEVEL, "IP ADDRESS OF THE SERVER: " +
+                    InetAddress.getLocalHost().toString().split("/")[1]);
         } catch (IOException e) {
             logger.log(Level.WARNING, "could't create server socket", e);
         }

--- a/src/main/java/com/spanish_inquisition/battleship/server/ClientConnectionHandler.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/ClientConnectionHandler.java
@@ -19,12 +19,12 @@ import static com.spanish_inquisition.battleship.server.BattleshipServer.SERVER_
 
 public class ClientConnectionHandler extends Thread {
     String name;
-    Socket clientSocket;
-    BufferedReader clientInput;
-    PrintWriter clientOutput;
-    final int clientId;
+    private Socket clientSocket;
+    private BufferedReader clientInput;
+    private PrintWriter clientOutput;
+    private final int clientId;
     private MessageBus requestBus;
-    boolean isConnected;
+    private boolean isConnected;
 
     public ClientConnectionHandler(final int clientId, MessageBus requestBus) {
         this.clientId = clientId;
@@ -32,15 +32,11 @@ public class ClientConnectionHandler extends Thread {
         this.isConnected = true;
     }
 
-    public int getClientId(){
+    int getClientId() {
         return clientId;
     }
 
-    public String getPlayerName() {
-        return name;
-    }
-
-    public void disconnect() {
+    void disconnect() {
         isConnected = false;
     }
 
@@ -48,7 +44,7 @@ public class ClientConnectionHandler extends Thread {
         clientSocket = serverSocket.accept();
     }
 
-    public void setUpStreams() throws IOException {
+    void setUpStreams() throws IOException {
         clientInput = new BufferedReader(
                 new InputStreamReader(clientSocket.getInputStream(),
                         StandardCharsets.UTF_8));
@@ -60,7 +56,7 @@ public class ClientConnectionHandler extends Thread {
     public void run() {
         name = acceptNameFromClient();
 
-        while(clientSocket.isConnected() && isConnected) {
+        while (clientSocket.isConnected() && isConnected) {
             sendMessageToUser(clientOutput);
             getMessageFromUser(clientInput);
             try {
@@ -75,7 +71,7 @@ public class ClientConnectionHandler extends Thread {
     private String acceptNameFromClient() {
         String readName = "";
         try {
-            if(clientInput != null) {
+            if (clientInput != null) {
                 while (!clientInput.ready()) {
                     Thread.sleep(10);
                 }
@@ -88,7 +84,7 @@ public class ClientConnectionHandler extends Thread {
     }
 
     private void sendMessageToUser(PrintWriter output) {
-        if(output != null) {
+        if (output != null) {
             if (requestBus.haveMessageForRecipient(clientId)) {
                 String messageToSend = requestBus.getMessageFor(clientId).getContent();
                 output.println(messageToSend);
@@ -98,10 +94,10 @@ public class ClientConnectionHandler extends Thread {
 
     private void getMessageFromUser(BufferedReader input) {
         try {
-            if(input != null) {
+            if (input != null) {
                 if (input.ready()) {
                     String lineFromClient = input.readLine();
-                    logger.log(DEFAULT_LEVEL, "Message from client " +clientId + " " + lineFromClient);
+                    logger.log(DEFAULT_LEVEL, "Message from client " + clientId + " " + lineFromClient);
                     if (lineFromClient != null && lineFromClient.trim().equals(Header.EXIT.name())) {
                         isConnected = false;
                     } else {

--- a/src/main/java/com/spanish_inquisition/battleship/server/Player.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/Player.java
@@ -32,11 +32,7 @@ public class Player {
     }
 
     public boolean fleetGotHit(Integer targetedField) {
-        if(fleet.pointIsClaimedByFleet(targetedField)) {
-            return true;
-        }
-
-        return false;
+        return fleet.pointIsClaimedByFleet(targetedField);
     }
 
     public boolean gotDestroyedShip() {

--- a/src/main/java/com/spanish_inquisition/battleship/server/bus/Message.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/bus/Message.java
@@ -11,11 +11,11 @@ public class Message {
         this.content = message;
     }
 
-    public boolean isToRecipient(int recipient) {
+    boolean isToRecipient(int recipient) {
         return this.recipient == recipient;
     }
 
-    public boolean isFromSender(int sender) {
+    boolean isFromSender(int sender) {
         return this.sender == sender;
     }
 
@@ -33,10 +33,10 @@ public class Message {
 
     @Override
     public String toString() {
-        return "Message{" +
-                "sender=" + sender +
-                ", recipient=" + recipient +
-                ", message='" + content + '\'' +
-                '}';
+        return "Message{"
+                + "sender=" + sender
+                + ", recipient=" + recipient
+                + ", message='" + content + '\''
+                + '}';
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/bus/MessageBuilder.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/bus/MessageBuilder.java
@@ -5,9 +5,9 @@ import com.spanish_inquisition.battleship.common.NetworkMessage;
 import com.spanish_inquisition.battleship.server.fleet.Ship;
 
 public class MessageBuilder {
-    Integer senderId;
-    Integer recipientId;
-    String messageContent;
+    private Integer senderId;
+    private Integer recipientId;
+    private String messageContent;
 
     public MessageBuilder(Integer senderId, Integer recipientId) {
         this.senderId = senderId;
@@ -15,52 +15,52 @@ public class MessageBuilder {
     }
 
     public MessageBuilder buildResponseHitMessage(Integer field) {
-        messageContent = Header.RESPONSE_HIT.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                field +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_HIT.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + field
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 
     public MessageBuilder buildResponseOpponentHitMessage(Integer field) {
-        messageContent = Header.RESPONSE_OPPONENT_HIT.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                field +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_OPPONENT_HIT.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + field
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 
     public MessageBuilder buildResponseMissMessage(Integer field) {
-        messageContent = Header.RESPONSE_MISS.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                field +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_MISS.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + field
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 
     public MessageBuilder buildResponseOpponentMissMessage(Integer field) {
-        messageContent = Header.RESPONSE_OPPONENT_MISS.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                field +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_OPPONENT_MISS.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + field
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 
     public MessageBuilder buildResponseDestroyedShipMessage(Ship destroyedShip) {
         String shipPointsAsString = destroyedShip.pointsAsString();
-        messageContent = Header.RESPONSE_DESTROYED_SHIP.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                shipPointsAsString +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_DESTROYED_SHIP.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + shipPointsAsString
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 
     public MessageBuilder buildResponseOpponentDestroyedShipMessage(Ship destroyedShip) {
         String shipPointsAsString = destroyedShip.pointsAsString();
-        messageContent = Header.RESPONSE_OPPONENT_DESTROYED_SHIP.name() +
-                NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER +
-                shipPointsAsString +
-                NetworkMessage.RESPONSE_SPLIT_CHARACTER;
+        messageContent = Header.RESPONSE_OPPONENT_DESTROYED_SHIP.name()
+                + NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER
+                + shipPointsAsString
+                + NetworkMessage.RESPONSE_SPLIT_CHARACTER;
         return this;
     }
 

--- a/src/main/java/com/spanish_inquisition/battleship/server/fleet/Fleet.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/fleet/Fleet.java
@@ -17,15 +17,16 @@ public class Fleet {
 
     @Override
     public String toString() {
-        return "Fleet{" +
-                "ships=" + ships +
-                '}';
+        return "Fleet{"
+                + "ships="
+                + ships
+                + '}';
     }
 
     public boolean hasNoShips() {
         boolean noShips = true;
-        for(Ship ship : ships) {
-            if(!ship.isDestroyed()) {
+        for (Ship ship : ships) {
+            if (!ship.isDestroyed()) {
                 noShips = false;
             }
         }
@@ -34,15 +35,14 @@ public class Fleet {
     }
 
     public boolean pointIsClaimedByFleet(Integer targetedPoint) {
-        for(Ship ship : ships) {
-            if(ship.gotHit(targetedPoint)){
-                if(ship.isDestroyed()) {
+        for (Ship ship : ships) {
+            if (ship.gotHit(targetedPoint)) {
+                if (ship.isDestroyed()) {
                     currentDestroyedShip = ship;
                 }
                 return true;
             }
         }
-
         return false;
     }
 

--- a/src/main/java/com/spanish_inquisition/battleship/server/fleet/FleetBuilder.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/fleet/FleetBuilder.java
@@ -35,15 +35,15 @@ public class FleetBuilder {
 
     private List<TwoMast> createTwoMastsFromFieldsList(List<Integer> shipsFields) {
         List<TwoMast> twoMasts = new ArrayList<>(3);
-        for(int i = 0; i < 3; i++)
+        for (int i = 0; i < 3; i++) {
             twoMasts.add(extractNewTwoMast(shipsFields));
-
+        }
         return twoMasts;
     }
 
     private TwoMast extractNewTwoMast(List<Integer> shipsFields) {
         List<Integer> twoMastFields = new ArrayList<>(2);
-        for(int i = 0; i < 2; i++) {
+        for (int i = 0; i < 2; i++) {
             twoMastFields.add(shipsFields.get(0));
             shipsFields.remove(0);
         }
@@ -52,15 +52,15 @@ public class FleetBuilder {
 
     private List<ThreeMast> createThreeMastsFromFieldsList(List<Integer> shipsFields) {
         List<ThreeMast> threeMasts = new ArrayList<>(2);
-        for(int i = 0; i < 2; i++)
+        for (int i = 0; i < 2; i++) {
             threeMasts.add(extractNewThreeMast(shipsFields));
-
+        }
         return threeMasts;
     }
 
     private ThreeMast extractNewThreeMast(List<Integer> shipsFields) {
         List<Integer> threeMastFields = new ArrayList<>(3);
-        for(int i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++) {
             threeMastFields.add(shipsFields.get(0));
             shipsFields.remove(0);
         }

--- a/src/main/java/com/spanish_inquisition/battleship/server/fleet/FleetParser.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/fleet/FleetParser.java
@@ -8,23 +8,22 @@ import java.util.logging.Level;
 
 import static com.spanish_inquisition.battleship.common.AppLogger.logger;
 
+class FleetParser {
 
-public class FleetParser {
-    public static List<Integer> parseMessageToIntegersList(String message) {
+    static List<Integer> parseMessageToIntegersList(String message) {
         String[] messageSplitted = message.split(String.valueOf(NetworkMessage.RESPONSE_HEADER_SPLIT_CHARACTER));
         return parseStringArrayToIntegerList(StringToStringArrayParser.parse(messageSplitted[1]));
     }
 
-    private static List<Integer> parseStringArrayToIntegerList(String[] strArr) {
-        List<Integer> intList = new ArrayList<>(strArr.length);
-        for (String aStrArr : strArr) {
+    private static List<Integer> parseStringArrayToIntegerList(String[] fleet) {
+        List<Integer> intList = new ArrayList<>(fleet.length);
+        for (String shipIndex : fleet) {
             try {
-                intList.add(Integer.parseInt(aStrArr));
-            } catch (NumberFormatException nfe) {
-                logger.log(Level.WARNING, "wrong number format", nfe);
+                intList.add(Integer.parseInt(shipIndex));
+            } catch (NumberFormatException e) {
+                logger.log(Level.WARNING, "wrong number format", e);
             }
         }
         return intList;
     }
-
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/fleet/Ship.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/fleet/Ship.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class Ship {
-    List<Integer> shipPoints;
-    List<Integer> damagedPoints;
+    private List<Integer> shipPoints;
+    private List<Integer> damagedPoints;
 
     public Ship(List<Integer> shipPoints) {
         this.shipPoints = shipPoints;
@@ -18,13 +18,13 @@ public abstract class Ship {
 
     @Override
     public String toString() {
-        return "Ship{" +
-                "shipPoints=" + shipPoints +
-                '}';
+        return "Ship{"
+                + "shipPoints=" + shipPoints
+                + '}';
     }
 
     public boolean gotHit(Integer targetedPoint) {
-        if(shipPoints.contains(targetedPoint)) {
+        if (shipPoints.contains(targetedPoint)) {
             damagedPoints.add(targetedPoint);
             shipPoints.remove(targetedPoint);
             return true;
@@ -32,7 +32,7 @@ public abstract class Ship {
         return false;
     }
 
-    public boolean isDestroyed() {
+    boolean isDestroyed() {
         return shipPoints.isEmpty();
     }
 

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/EndState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/EndState.java
@@ -1,10 +1,10 @@
 package com.spanish_inquisition.battleship.server.game_states;
 
-import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.bus.MessageBus;
 
 public class EndState extends GameState {
-    public EndState(Players players, MessageBus requestBus) {
+    EndState(Players players, MessageBus requestBus) {
         super(players, requestBus);
     }
 

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/GameState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/GameState.java
@@ -1,7 +1,7 @@
 package com.spanish_inquisition.battleship.server.game_states;
 
-import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.bus.MessageBus;
 
 public abstract class GameState {
     protected Players players;

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/PlacingShipsState.java
@@ -1,9 +1,9 @@
 package com.spanish_inquisition.battleship.server.game_states;
 
 import com.spanish_inquisition.battleship.common.Header;
-import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.Player;
 import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.fleet.FleetBuilder;
 import com.spanish_inquisition.battleship.server.fleet.FleetValidator;
 

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/PlayerActionState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/PlayerActionState.java
@@ -1,21 +1,22 @@
 package com.spanish_inquisition.battleship.server.game_states;
 
 import com.spanish_inquisition.battleship.common.Header;
-import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.bus.MessageBus;
 
 import static com.spanish_inquisition.battleship.server.BattleshipServer.SERVER_ID;
 
 public class PlayerActionState extends GameState {
 
-    public PlayerActionState(Players players, MessageBus requestBus) {
+    PlayerActionState(Players players, MessageBus requestBus) {
         super(players, requestBus);
     }
 
     @Override
     public GameState transform() {
         requestBus.addMessage(SERVER_ID, players.getCurrentPlayer().getPlayerId(), Header.PLAYER_TURN.name());
-        requestBus.addMessage(SERVER_ID, players.getOpponentOf(players.getCurrentPlayer()).getPlayerId(), Header.OPPONENT_TURN.name());
+        requestBus.addMessage(SERVER_ID, players.getOpponentOf(players.getCurrentPlayer()).getPlayerId(),
+                Header.OPPONENT_TURN.name());
         return new ShotState(players, requestBus);
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/ResultState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/ResultState.java
@@ -9,7 +9,7 @@ import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import static com.spanish_inquisition.battleship.server.BattleshipServer.SERVER_ID;
 
 public class ResultState extends GameState {
-    public ResultState(Players players, MessageBus requestBus) {
+    ResultState(Players players, MessageBus requestBus) {
         super(players, requestBus);
     }
 
@@ -21,10 +21,13 @@ public class ResultState extends GameState {
 
     private void buildWinnerResponse() {
         Player winner = players.getWinner();
-        if(winner == null) {return;}
-        NetworkMessage winningMessage = new NetworkMessage(Header.GAME_WON, "true");
-        NetworkMessage losingMessage = new NetworkMessage(Header.GAME_WON, "false");
-        requestBus.addMessage(SERVER_ID, players.getWinner().getPlayerId(), NetworkMessage.Parser.parseMessageToString(winningMessage));
-        requestBus.addMessage(SERVER_ID, players.getOpponentOf(players.getWinner()).getPlayerId(), NetworkMessage.Parser.parseMessageToString(losingMessage));
+        if (winner != null) {
+            NetworkMessage winningMessage = new NetworkMessage(Header.GAME_WON, "true");
+            NetworkMessage losingMessage = new NetworkMessage(Header.GAME_WON, "false");
+            requestBus.addMessage(SERVER_ID, players.getWinner().getPlayerId(),
+                    NetworkMessage.Parser.parseMessageToString(winningMessage));
+            requestBus.addMessage(SERVER_ID, players.getOpponentOf(players.getWinner()).getPlayerId(),
+                    NetworkMessage.Parser.parseMessageToString(losingMessage));
+        }
     }
 }

--- a/src/main/java/com/spanish_inquisition/battleship/server/game_states/ShotState.java
+++ b/src/main/java/com/spanish_inquisition/battleship/server/game_states/ShotState.java
@@ -2,17 +2,16 @@ package com.spanish_inquisition.battleship.server.game_states;
 
 import com.spanish_inquisition.battleship.common.Header;
 import com.spanish_inquisition.battleship.common.NetworkMessage;
-import com.spanish_inquisition.battleship.server.bus.MessageBuilder;
-import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.Player;
 import com.spanish_inquisition.battleship.server.Players;
+import com.spanish_inquisition.battleship.server.bus.MessageBuilder;
+import com.spanish_inquisition.battleship.server.bus.MessageBus;
 import com.spanish_inquisition.battleship.server.fleet.Ship;
-
 
 import static com.spanish_inquisition.battleship.server.BattleshipServer.SERVER_ID;
 
 public class ShotState extends GameState {
-    public ShotState(final Players players, final MessageBus requestBus) {
+    ShotState(final Players players, final MessageBus requestBus) {
         super(players, requestBus);
     }
 
@@ -28,13 +27,13 @@ public class ShotState extends GameState {
         }
         return !didPlayerWon(currentPlayer)
                 ? new PlayerActionState(
-                        players, requestBus)
+                players, requestBus)
                 : new ResultState(
-                        players, requestBus);
+                players, requestBus);
     }
 
     private boolean didPlayerWon(final Player player) {
-        if(players.getOpponentOf(player).hasNoFleet()) {
+        if (players.getOpponentOf(player).hasNoFleet()) {
             players.setWinner(player);
             return true;
         }

--- a/src/test/java/com/spanish_inquisition/battleship/client/board/GameBoardBuilderTest.java
+++ b/src/test/java/com/spanish_inquisition/battleship/client/board/GameBoardBuilderTest.java
@@ -41,7 +41,7 @@ public class GameBoardBuilderTest {
         GameBoardBuilder boardBuilder = new GameBoardBuilder(controller);
 
         // When
-        boardBuilder.buildGameBoard();
+        boardBuilder.fillTheBoardWithButtonsAndLabels();
         waitForRunLater();
 
         // Then


### PR DESCRIPTION
Organize imports; divide too long lines; add missing spaces to reduce number of checkstyle warnings.